### PR TITLE
Updated README to adhere to Rubocop preferred syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ When you create a new folder under `/controllers`, Rails will automatically pick
 ```ruby
 # controllers/admin/stats_controller.rb
 
-class Admin::StatsController < ApplicationController
-  def index
+module Admin
+  class StatsController < ApplicationController
+    def index
 
-    ...
+      ...
 
+    end
   end
 end
 ```


### PR DESCRIPTION
When implementing the previous syntax of:
class Admin::StatsController < ApplicationController
into the lab following this README, rubocop would error out.